### PR TITLE
v2.2.2.1, Enigma v1.2

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -9,7 +9,7 @@
 #define CLIENT_VERSION_MAJOR       2
 #define CLIENT_VERSION_MINOR       2
 #define CLIENT_VERSION_REVISION    2
-#define CLIENT_VERSION_BUILD       0
+#define CLIENT_VERSION_BUILD       1
 
 // Copyright year (2009-this)
 // Todo: update this when changing our copyright comments in the source

--- a/src/enigma/enigma.cpp
+++ b/src/enigma/enigma.cpp
@@ -1033,10 +1033,10 @@ bool Enigma::HandleCloakOnionData(CCloakingData cloakDataIn, CNode* node, int le
 
         if (!alreadyProcessed)
         {
+	    Sleep(10);
             cloakDataIn.hops++;
 
             if (level > 0){
-		Sleep(10);
                 cloakDataIn.Transmit(NULL, true, false); // forward to all as we've unpacked a layer
             }else{
                 cloakDataIn.Transmit(node, true, false); // forward to all but sender, sending as is

--- a/src/enigma/enigma.cpp
+++ b/src/enigma/enigma.cpp
@@ -1036,6 +1036,7 @@ bool Enigma::HandleCloakOnionData(CCloakingData cloakDataIn, CNode* node, int le
             cloakDataIn.hops++;
 
             if (level > 0){
+		Sleep(10);
                 cloakDataIn.Transmit(NULL, true, false); // forward to all as we've unpacked a layer
             }else{
                 cloakDataIn.Transmit(node, true, false); // forward to all but sender, sending as is

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -943,7 +943,11 @@ void ThreadSocketHandler2(void* parg)
                     CDataStream& vRecv = pnode->vRecv;
                     unsigned int nPos = vRecv.size();
 
-                    if (nPos > ReceiveBufferSize()) {
+                    if (nPos >= (0.8 * ReceiveBufferSize())) {
+			Sleep((2000 * nPos)/(0.8 * ReceiveBufferSize()));
+		    }
+		    
+		    if (nPos > ReceiveBufferSize()) {
                         if (!pnode->fDisconnect)
                             printf("socket recv flood control disconnect (%" PRIszu " bytes)\n", vRecv.size());
                         pnode->CloseSocketDisconnect();

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -94,7 +94,7 @@ BitcoinGUI::BitcoinGUI(bool fIsTestnet, QWidget *parent):
     rpcConsole(0)
 {
     resize(850, 550);
-    setWindowTitle(tr("CLOAK Core v2.2.2.0 rEvolution"));
+    setWindowTitle(tr("CLOAK Core v2.2.2.1 rEvolution"));
 #ifndef Q_OS_MAC
     qApp->setWindowIcon(QIcon(":icons/bitcoin"));
     setWindowIcon(QIcon(":icons/bitcoin"));

--- a/src/util.h
+++ b/src/util.h
@@ -56,7 +56,7 @@ typedef int pid_t; /* define for Windows compatibility */
 #define ENIGMA_MIN_FEE_SENDAMOUNT 1000000000 // 1,000 coins
 #define ENIGMA_TOTAL_FEE_PERCENT(x) (x > ENIGMA_MIN_FEE_SENDAMOUNT ? ENIGMA_MIN_FEE_PERCENT : ((ENIGMA_MAX_FEE_PERCENT - ENIGMA_MIN_FEE_PERCENT)*(ENIGMA_MIN_FEE_SENDAMOUNT-x)/ENIGMA_MIN_FEE_SENDAMOUNT) + ENIGMA_MIN_FEE_PERCENT ) // % of total cloaks randomly split between participants (per request) as a reward
 #define ENIGMA_MAX_CONCURRENT_TRANSACTIONS 3 // how many enigma transasctions can we have in play at any one time?
-#define ENIGMA_REQUEST_CURRENTVERSION 0011 // current version number of Enigma cloaking requests. Ignore requests with lesser or greater version #.
+#define ENIGMA_REQUEST_CURRENTVERSION 0012 // current version number of Enigma cloaking requests. Ignore requests with lesser or greater version #.
 #define ENIGMA_BANSECS_MISSING_INPUTS 600 // when enigma nodes fails to provide valid inputs for a cloaking op
 #define ENIGMA_BANSECS_NO_RESPONSE 120 // when enigma nodes fails to respond to a signing request
 #define ENIGMA_BANSECS_JUNK_DATA 120 // when enigma nodes fails to respond to a signing request

--- a/src/util.h
+++ b/src/util.h
@@ -47,7 +47,7 @@ typedef int pid_t; /* define for Windows compatibility */
 #define CLOAKSHIELD_MAX_HOPS 64
 
 // Enigma flags/settings
-#define ENIGMA_ENGINE_VER "1.1"
+#define ENIGMA_ENGINE_VER "1.2"
 
 #define ENIGMA_MAX_COINAGE_DAYS 7 // if coins have more than [ENIGMA_MAX_COINAGE_DAYS] of coin age, they will be excluded from Enigma sending/mixing
 #define ENIGMA_TX_LOCKTIME_SECS 0 // 5 minsGetTime()

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -11,7 +11,7 @@
 const std::string CLIENT_NAME("KlausFuchs");
 
 // Client version number
-#define CLIENT_VERSION_SUFFIX   " 'rEVOLUTION'"
+#define CLIENT_VERSION_SUFFIX   " 'rEVOLUTION' stormfix"
 
 // The following part of the code determines the CLIENT_BUILD variable.
 // Several mechanisms are used for this:

--- a/src/version.h
+++ b/src/version.h
@@ -55,6 +55,6 @@ static const int MEMPOOL_GD_VERSION = 60002;
 #define DISPLAY_VERSION_MAJOR       2
 #define DISPLAY_VERSION_MINOR       2
 #define DISPLAY_VERSION_REVISION    2
-#define DISPLAY_VERSION_BUILD       0
+#define DISPLAY_VERSION_BUILD       1
 
 #endif


### PR DESCRIPTION
Attempt to fix the d/c storm issue associated with Enigma transactions. The issue is not (and was not) reproducible on devnet or testnet with relatively small number of nodes - hard to say this is the final solution without testing it "in the wild" as the problem seems to be network and/or bandwidth related.

To isolate the send/receive mechanics from previous client versions that have the issue, Enigma v1.2 **is not** backwards compatible.