### PR TITLE
increase the messaging delay to 100ms

### DIFF
--- a/src/enigma/enigma.cpp
+++ b/src/enigma/enigma.cpp
@@ -1033,7 +1033,7 @@ bool Enigma::HandleCloakOnionData(CCloakingData cloakDataIn, CNode* node, int le
 
         if (!alreadyProcessed)
         {
-	    Sleep(10);
+	    Sleep(100);
             cloakDataIn.hops++;
 
             if (level > 0){


### PR DESCRIPTION
Potential improvement of the Enigma stability, reducing messaging throughput to free up more buffer in Enigma-enabled nodes.